### PR TITLE
Fix null-safety and loading states

### DIFF
--- a/lib/screens/chat_list_screen.dart
+++ b/lib/screens/chat_list_screen.dart
@@ -8,9 +8,10 @@ class ChatListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final uid = FirebaseAuth.instance.currentUser?.uid;
+    final user = FirebaseAuth.instance.currentUser;
+    final uid = user?.uid;
 
-    if (uid == null || FirebaseAuth.instance.currentUser!.isAnonymous) {
+    if (uid == null || (user?.isAnonymous ?? true)) {
       return Scaffold(
         appBar: AppBar(
           backgroundColor: Colors.white,
@@ -48,7 +49,7 @@ class ChatListScreen extends StatelessWidget {
             .orderBy('lastMessageTime', descending: true)
             .snapshots(),
         builder: (context, snapshot) {
-          if (!snapshot.hasData) {
+          if (!snapshot.hasData || snapshot.data == null) {
             return const Center(child: CircularProgressIndicator());
           }
 
@@ -68,9 +69,14 @@ class ChatListScreen extends StatelessWidget {
               final otherUserId = users.firstWhere((id) => id != uid);
 
               return FutureBuilder<DocumentSnapshot>(
-                future: FirebaseFirestore.instance.collection('users').doc(otherUserId).get(),
+                future: FirebaseFirestore.instance
+                    .collection('users')
+                    .doc(otherUserId)
+                    .get(),
                 builder: (context, userSnapshot) {
-                  if (!userSnapshot.hasData) return const SizedBox.shrink();
+                  if (!userSnapshot.hasData || userSnapshot.data == null) {
+                    return const SizedBox.shrink();
+                  }
 
                   final userData = userSnapshot.data!.data() as Map<String, dynamic>? ?? {};
                   final displayName = userData['name'] ?? 'User';

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -102,6 +102,9 @@ class _ChatScreenState extends State<ChatScreen> {
                 stream: _chatRef.collection('typing').doc(widget.receiverId).snapshots(),
                 builder: (context, snapshot) {
                   final isTyping = snapshot.data?.get('typing') == true;
+                  if (!snapshot.hasData || snapshot.data == null) {
+                    return const SizedBox.shrink();
+                  }
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -125,7 +128,7 @@ class _ChatScreenState extends State<ChatScreen> {
             child: StreamBuilder<QuerySnapshot>(
               stream: _messagesRef.orderBy('timestamp', descending: false).snapshots(),
               builder: (context, snapshot) {
-                if (!snapshot.hasData) return const Center(child: CircularProgressIndicator());
+                if (!snapshot.hasData || snapshot.data == null) return const Center(child: CircularProgressIndicator());
 
                 final messages = snapshot.data!.docs;
                 if (messages.isEmpty) return const Center(child: Text('No messages yet.'));

--- a/lib/screens/landing_screen.dart
+++ b/lib/screens/landing_screen.dart
@@ -53,7 +53,6 @@ class _LandingScreenState extends State<LandingScreen> {
     if (!seen) {
       setState(() => _showIntro = true);
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
         showDialog(
           context: context,
           barrierDismissible: false,
@@ -62,9 +61,9 @@ class _LandingScreenState extends State<LandingScreen> {
             onFinish: () async {
               final prefs = await SharedPreferences.getInstance();
               await prefs.setBool('intro_done', true);
-              if (mounted) {
-                setState(() => _showIntro = false);
-                Navigator.of(context).pop();
+              if (!mounted) return;
+              setState(() => _showIntro = false);
+              Navigator.of(context).pop();
               }
             },
           ),
@@ -162,6 +161,7 @@ class _HomePageContentState extends State<HomePageContent> {
   Future<void> _fetchLocation() async {
     try {
       final pos = await Geolocator.getCurrentPosition();
+      if (!mounted) return;
       setState(() => _userLocation = pos);
     } catch (e) {
       debugPrint("📍 Location error: $e");
@@ -301,6 +301,7 @@ class _HomePageContentState extends State<HomePageContent> {
                     return FutureBuilder<DocumentSnapshot>(
                       future: FirebaseFirestore.instance.collection('users').doc(creatorId).get(),
                       builder: (context, userSnapshot) {
+                        if (!userSnapshot.hasData || userSnapshot.data == null) return SizedBox.shrink();
                         final userData = userSnapshot.data?.data() as Map<String, dynamic>?;
 
                         final userName = userData?['name'] ?? 'User';
@@ -393,7 +394,7 @@ class _HomePageContentState extends State<HomePageContent> {
                                           FutureBuilder<DocumentSnapshot>(
                                             future: FirebaseFirestore.instance.collection('posts').doc(postId).get(),
                                             builder: (context, snapshot) {
-                                              if (!snapshot.hasData) return const SizedBox.shrink();
+                                              if (!snapshot.hasData || snapshot.data == null) return const SizedBox.shrink();
                                               final postData = snapshot.data!.data() as Map<String, dynamic>;
                                               final count = postData['likesCount'] ?? 0;
                                               return Padding(
@@ -447,6 +448,7 @@ class _HomePageContentState extends State<HomePageContent> {
                                                       ),
                                                     ),
                                                   );
+                                                  if (!mounted) return;
 
                                                   setState(() => _isNavigating = false);
                                                 },

--- a/lib/screens/marketplace_screen.dart
+++ b/lib/screens/marketplace_screen.dart
@@ -43,6 +43,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
 
   Future<void> _fetchLocation() async {
     final pos = await LocationService.getCurrentLocation();
+    if (!mounted) return;
     setState(() => _userLocation = pos);
   }
 
@@ -168,7 +169,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
                     return const Center(child: Text("Error loading posts."));
                   }
 
-                  if (!snapshot.hasData) {
+                  if (!snapshot.hasData || snapshot.data == null) {
                     return const Center(child: CircularProgressIndicator());
                   }
 
@@ -271,6 +272,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
                               FutureBuilder<DocumentSnapshot>(
                                 future: FirebaseFirestore.instance.collection('users').doc(creatorId).get(),
                                 builder: (context, userSnapshot) {
+                                  if (!userSnapshot.hasData || userSnapshot.data == null) return SizedBox.shrink();
                                   final userData = userSnapshot.data?.data() as Map<String, dynamic>?;
 
                                   final userName = userData?['name'] ?? 'User';
@@ -306,6 +308,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
                                             ),
                                           ),
                                         );
+                                          if (!mounted) return;
 
                                         setState(() => _isNavigating = false);
                                       },

--- a/lib/screens/nearby_highlights_screen.dart
+++ b/lib/screens/nearby_highlights_screen.dart
@@ -33,6 +33,7 @@ class _NearbyHighlightsScreenState extends State<NearbyHighlightsScreen> {
 
       final allDocs = query.docs;
       if (allDocs.isEmpty) {
+        if (!mounted) return;
         setState(() {
           _loading = false;
           _swipeItems = [];
@@ -57,14 +58,14 @@ class _NearbyHighlightsScreenState extends State<NearbyHighlightsScreen> {
         );
       }).toList();
 
-      if (mounted) {
-        setState(() {
-          _matchEngine = MatchEngine(swipeItems: _swipeItems);
-          _loading = false;
-        });
-      }
+      if (!mounted) return;
+      setState(() {
+        _matchEngine = MatchEngine(swipeItems: _swipeItems);
+        _loading = false;
+      });
     } catch (e) {
       print("❌ Error loading products: $e");
+      if (!mounted) return;
       setState(() => _loading = false);
     }
   }

--- a/lib/screens/notification_screen.dart
+++ b/lib/screens/notification_screen.dart
@@ -35,6 +35,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
         .where('read', isEqualTo: false)
         .snapshots()
         .listen((snapshot) {
+      if (!mounted) return;
       setState(() {
         unreadCount = snapshot.docs.length;
       });
@@ -136,7 +137,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const Center(child: CircularProgressIndicator());
                   }
-                  if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                  if (!snapshot.hasData || snapshot.data == null || snapshot.data!.docs.isEmpty) {
                     return const Center(child: Text("No notifications yet."));
                   }
 

--- a/lib/screens/post_creation_screen.dart
+++ b/lib/screens/post_creation_screen.dart
@@ -53,6 +53,7 @@ class _PostCreationScreenState extends State<PostCreationScreen> {
     }
 
     final position = await Geolocator.getCurrentPosition();
+    if (!mounted) return;
     setState(() {
       _latitude = position.latitude;
       _longitude = position.longitude;
@@ -61,6 +62,7 @@ class _PostCreationScreenState extends State<PostCreationScreen> {
 
   Future<void> _pickImage() async {
     final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+    if (!mounted) return;
     if (pickedFile != null) {
       setState(() => _imageFile = File(pickedFile.path));
     }
@@ -136,6 +138,7 @@ final user = FirebaseAuth.instance.currentUser;
       print("❌ Upload Error: $e");
       _showSnack("❌ Something went wrong. Try again.");
     } finally {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -40,8 +40,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
       final doc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
       final data = doc.data();
 
-      if (mounted) {
-        setState(() {
+      if (!mounted) return;
+      setState(() {
           _userName = data?['name'] ?? 'User';
           _bioController.text = data?['bio'] ?? '';
           _phoneController.text = data?['phone'] ?? '';
@@ -52,7 +52,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
         });
       }
     } catch (e) {
-      if (mounted) setState(() => _isLoading = false);
+      if (!mounted) return;
+      setState(() => _isLoading = false);
     }
   }
 
@@ -80,28 +81,27 @@ class _ProfileScreenState extends State<ProfileScreen> {
         'showInReemYouth': _showInReemYouth,
       }, SetOptions(merge: true));
 
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text("✅ Profile updated")),
         );
-        setState(() {
-          _imageUrl = newImageUrl;
-          _profileImage = null;
-          _isLoading = false;
-        });
-      }
+      setState(() {
+        _imageUrl = newImageUrl;
+        _profileImage = null;
+        _isLoading = false;
+      });
     } catch (e) {
-      if (mounted) {
-        setState(() => _isLoading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
+      if (!mounted) return;
+      setState(() => _isLoading = false);
+      ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text("❌ Failed to update profile")),
         );
-      }
     }
   }
 
   Future<void> _pickImage() async {
     final picked = await ImagePicker().pickImage(source: ImageSource.gallery);
+    if (!mounted) return;
     if (picked != null) {
       setState(() => _profileImage = File(picked.path));
     }

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -36,11 +36,10 @@ class _SplashScreenState extends State<SplashScreen> {
       targetScreen = const LoginScreen();
     }
 
-    if (mounted) {
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => targetScreen),
-      );
-    }
+    if (!mounted) return;
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => targetScreen),
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- guard against null `snapshot.data` in builders
- check `mounted` before calling `setState`
- ensure user is not null before using `FirebaseAuth.instance.currentUser`

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845828a4dc8832c8d131e44ef7bb4af