### PR TITLE
Fix chat creation and improve firebase screens

### DIFF
--- a/lib/screens/chat_list_screen.dart
+++ b/lib/screens/chat_list_screen.dart
@@ -44,11 +44,11 @@ class ChatListScreen extends StatelessWidget {
       body: StreamBuilder<QuerySnapshot>(
         stream: FirebaseFirestore.instance
             .collection('chats')
-            .where('users', arrayContains: uid)
+            .where('participants', arrayContains: uid)
             .orderBy('lastMessageTime', descending: true)
             .snapshots(),
         builder: (context, snapshot) {
-          if (!snapshot.hasData) {
+          if (!snapshot.hasData || snapshot.data == null) {
             return const Center(child: CircularProgressIndicator());
           }
 
@@ -64,13 +64,13 @@ class ChatListScreen extends StatelessWidget {
             itemBuilder: (context, index) {
               final chat = chats[index];
               final data = chat.data() as Map<String, dynamic>;
-              final users = List<String>.from(data['users']);
+              final users = List<String>.from(data['participants']);
               final otherUserId = users.firstWhere((id) => id != uid);
 
               return FutureBuilder<DocumentSnapshot>(
                 future: FirebaseFirestore.instance.collection('users').doc(otherUserId).get(),
                 builder: (context, userSnapshot) {
-                  if (!userSnapshot.hasData) return const SizedBox.shrink();
+                  if (!userSnapshot.hasData || userSnapshot.data == null) return const SizedBox.shrink();
 
                   final userData = userSnapshot.data!.data() as Map<String, dynamic>? ?? {};
                   final displayName = userData['name'] ?? 'User';

--- a/lib/screens/notification_screen.dart
+++ b/lib/screens/notification_screen.dart
@@ -35,6 +35,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
         .where('read', isEqualTo: false)
         .snapshots()
         .listen((snapshot) {
+      if (!mounted) return;
       setState(() {
         unreadCount = snapshot.docs.length;
       });
@@ -54,6 +55,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
   }
 
   Future<void> _refreshNotifications() async {
+    if (!mounted) return;
     setState(() {});
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Notifications refreshed.')),
@@ -136,7 +138,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const Center(child: CircularProgressIndicator());
                   }
-                  if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                  if (!snapshot.hasData || snapshot.data == null || snapshot.data!.docs.isEmpty) {
                     return const Center(child: Text("No notifications yet."));
                   }
 

--- a/lib/screens/post_creation_screen.dart
+++ b/lib/screens/post_creation_screen.dart
@@ -53,6 +53,7 @@ class _PostCreationScreenState extends State<PostCreationScreen> {
     }
 
     final position = await Geolocator.getCurrentPosition();
+    if (!mounted) return;
     setState(() {
       _latitude = position.latitude;
       _longitude = position.longitude;
@@ -62,6 +63,7 @@ class _PostCreationScreenState extends State<PostCreationScreen> {
   Future<void> _pickImage() async {
     final pickedFile = await picker.pickImage(source: ImageSource.gallery);
     if (pickedFile != null) {
+      if (!mounted) return;
       setState(() => _imageFile = File(pickedFile.path));
     }
   }
@@ -136,6 +138,7 @@ final user = FirebaseAuth.instance.currentUser;
       print("❌ Upload Error: $e");
       _showSnack("❌ Something went wrong. Try again.");
     } finally {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }


### PR DESCRIPTION
## Summary
- ensure async setState calls check `mounted`
- create chat documents with `participants` list using a transaction
- query chats by `participants` list
- guard StreamBuilder calls from null snapshots

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6845864b71f4832cab6b33cc0d9d046f