### PR TITLE
Fix routing and avatar fallback

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,14 @@ import 'package:provider/provider.dart';
 import 'firebase_options.dart';
 
 import 'screens/splash_screen.dart';
+import 'screens/login_screen.dart';
+import 'screens/landing_screen.dart';
+import 'screens/profile_screen.dart';
+import 'screens/menu_screen.dart';
+import 'screens/search_screen.dart';
+import 'screens/social_login_screen.dart';
+import 'screens/onboarding_screen.dart';
+import 'screens/welcome_screen.dart';
 import 'providers/locale_provider.dart';
 
 void main() async {
@@ -25,9 +33,19 @@ class MyApp extends StatelessWidget {
             title: 'Reem Verse',
             debugShowCheckedModeBanner: false,
             theme: ThemeData(primarySwatch: Colors.blue),
-            // اللغة الآن غير مدعومة، فنبقي locale فقط لو تستخدمها بطريقة مخصصة
             locale: provider.locale,
-            home: const SplashScreen(),
+            initialRoute: '/splash',
+            routes: {
+              '/splash': (_) => const SplashScreen(),
+              '/login': (_) => const LoginScreen(),
+              '/landing': (_) => const LandingScreen(),
+              '/profile': (_) => const ProfileScreen(),
+              '/menu': (_) => const MainMenuScreen(),
+              '/search': (_) => const SearchScreen(),
+              '/social': (_) => const SocialLoginScreen(),
+              '/onboarding': (_) => const OnboardingScreen(),
+              '/welcome': (_) => const WelcomeScreen(),
+            },
           );
         },
       ),

--- a/lib/screens/auth/signup_screen.dart
+++ b/lib/screens/auth/signup_screen.dart
@@ -46,9 +46,7 @@ class _SignupScreenState extends State<SignupScreen> {
         'createdAt': Timestamp.now(),
       });
 
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const WelcomeScreen()),
-      );
+      Navigator.of(context).pushReplacementNamed('/welcome');
     } on FirebaseAuthException catch (e) {
       String message = "Signup failed.";
       if (e.code == 'email-already-in-use') message = "Email is already registered.";

--- a/lib/screens/auth/sms_verification_screen.dart
+++ b/lib/screens/auth/sms_verification_screen.dart
@@ -41,9 +41,7 @@ class _SmsVerificationScreenState extends State<SmsVerificationScreen> {
 
       await FirebaseAuth.instance.signInWithCredential(credential);
 
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const LandingScreen()),
-      );
+      Navigator.of(context).pushReplacementNamed('/landing');
     } on FirebaseAuthException catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text("Verification failed: ${e.message}")),

--- a/lib/screens/landing_screen.dart
+++ b/lib/screens/landing_screen.dart
@@ -330,7 +330,8 @@ class _HomePageContentState extends State<HomePageContent> {
                                       leading: CircleAvatar(
                                         backgroundImage: userImage.isNotEmpty
                                             ? NetworkImage(userImage)
-                                            : const AssetImage('assets/user.png')
+                                            : const AssetImage(
+                                                'assets/images/default_user.png')
                                                 as ImageProvider,
                                         radius: 20,
                                       ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -35,9 +35,7 @@ class _LoginScreenState extends State<LoginScreen> {
       await prefs.setBool('isLoggedIn', true);
 
       if (!mounted) return;
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const LandingScreen()),
-      );
+      Navigator.of(context).pushReplacementNamed('/landing');
     } on FirebaseAuthException catch (e) {
       String message = "Login failed";
       if (e.code == 'user-not-found') {

--- a/lib/screens/menu_screen.dart
+++ b/lib/screens/menu_screen.dart
@@ -122,8 +122,8 @@ class MainMenuScreen extends StatelessWidget {
                       await prefs.setBool('isLoggedIn', false);
 
                       if (!context.mounted) return;
-                      Navigator.of(context).pushAndRemoveUntil(
-                        MaterialPageRoute(builder: (_) => const LoginScreen()),
+                      Navigator.of(context).pushNamedAndRemoveUntil(
+                        '/login',
                         (route) => false,
                       );
                     },

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -24,9 +24,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('isFirstTime', false);
     if (!mounted) return;
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => const LoginScreen()),
-    );
+    Navigator.of(context).pushReplacementNamed('/login');
   }
 
   void _nextPage() {

--- a/lib/screens/post_creation_screen.dart
+++ b/lib/screens/post_creation_screen.dart
@@ -126,11 +126,7 @@ final user = FirebaseAuth.instance.currentUser;
 
       _showSnack("✅ Post created successfully!");
       Future.delayed(const Duration(seconds: 1), () {
-        Navigator.of(context).pushReplacement(
-          MaterialPageRoute(
-            builder: (_) => const LandingScreen(initialIndex: 0),
-          ),
-        );
+        Navigator.of(context).pushReplacementNamed('/landing');
       });
     } catch (e) {
       print("❌ Upload Error: $e");

--- a/lib/screens/post_screen.dart
+++ b/lib/screens/post_screen.dart
@@ -218,16 +218,18 @@ class _PostScreenState extends State<PostScreen> {
               IconButton(
                 icon: const Icon(Icons.home, color: blueColor),
                 onPressed: () {
-                  Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(builder: (_) => const LandingScreen()),
-                  );
+                  Navigator.of(context).pushReplacementNamed('/landing');
                 },
               ),
               IconButton(
                 icon: const Icon(Icons.store, color: blueColor),
                 onPressed: () {
                   Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(builder: (_) => const MarketplaceScreen()),
+                    PageRouteBuilder(
+                      pageBuilder: (_, __, ___) => const MarketplaceScreen(),
+                      transitionDuration: Duration.zero,
+                      reverseTransitionDuration: Duration.zero,
+                    ),
                   );
                 },
               ),
@@ -235,17 +237,13 @@ class _PostScreenState extends State<PostScreen> {
               IconButton(
                 icon: const Icon(Icons.person, color: blueColor),
                 onPressed: () {
-                  Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(builder: (_) => const ProfileScreen()),
-                  );
+                  Navigator.of(context).pushReplacementNamed('/profile');
                 },
               ),
               IconButton(
                 icon: const Icon(Icons.menu, color: blueColor),
                 onPressed: () {
-                  Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(builder: (_) => const MainMenuScreen()),
-                  );
+                  Navigator.of(context).pushReplacementNamed('/menu');
                 },
               ),
             ],

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -115,7 +115,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
     } else if (_imageUrl.isNotEmpty) {
       imageProvider = NetworkImage(_imageUrl);
     } else {
-      imageProvider = const AssetImage('assets/images/default_user.png');
+      imageProvider = NetworkImage(
+        'https://ui-avatars.com/api/?name=${Uri.encodeComponent(_userName)}&background=0D8ABC&color=fff',
+      );
     }
 
     return CircleAvatar(

--- a/lib/screens/social_login_screen.dart
+++ b/lib/screens/social_login_screen.dart
@@ -63,9 +63,7 @@ class _SocialLoginScreenState extends State<SocialLoginScreen> {
   }
 
   void _navigateToLanding() {
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => const LandingScreen()),
-    );
+    Navigator.of(context).pushReplacementNamed('/landing');
   }
 
   void _showError(String message) {

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -27,19 +27,17 @@ class _SplashScreenState extends State<SplashScreen> {
     final isFirstTime = prefs.getBool('isFirstTime') ?? true;
     final user = FirebaseAuth.instance.currentUser;
 
-    Widget targetScreen;
+    String targetRoute;
     if (user != null) {
-      targetScreen = const LandingScreen();
+      targetRoute = '/landing';
     } else if (isFirstTime) {
-      targetScreen = const OnboardingScreen();
+      targetRoute = '/onboarding';
     } else {
-      targetScreen = const LoginScreen();
+      targetRoute = '/login';
     }
 
     if (mounted) {
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => targetScreen),
-      );
+      Navigator.of(context).pushReplacementNamed(targetRoute);
     }
   }
 

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -15,10 +15,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       Future.delayed(const Duration(seconds: 3), () {
         if (mounted) {
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(builder: (_) => const LandingScreen()),
-          );
+          Navigator.pushReplacementNamed(context, '/landing');
         }
       });
     });


### PR DESCRIPTION
## Summary
- replace missing user avatar with a default asset
- use online avatar fallback on profile page
- add route map to `MaterialApp`
- navigate using named routes for login and landing screens

## Testing
- `flutter test` *(fails: flutter not installed)*
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68457e1ec114832c838afbeff893005a