### PR TITLE
Fix search screen loading and add error states

### DIFF
--- a/lib/screens/post_details_screen.dart
+++ b/lib/screens/post_details_screen.dart
@@ -81,8 +81,15 @@ class _PostDetailsScreenState extends State<PostDetailsScreen> {
       body: FutureBuilder<DocumentSnapshot>(
         future: _postRef.get(),
         builder: (context, snapshot) {
-          if (!snapshot.hasData) return const Center(child: CircularProgressIndicator());
-          if (!snapshot.data!.exists) return const Center(child: Text("Post not found."));
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(child: Text("Error loading post."));
+          }
+          if (!snapshot.hasData || !snapshot.data!.exists) {
+            return const Center(child: Text("Post not found."));
+          }
 
           final data = snapshot.data!.data() as Map<String, dynamic>;
           final imageUrl = data['imageUrl'] ?? '';


### PR DESCRIPTION
## Summary
- ensure SearchScreen queries return results once using FutureBuilder
- handle potential errors when loading post details

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445ec20c58832c9781fbd00ddb8f5e