### PR TITLE
Add named routes and update navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,20 @@ import 'package:provider/provider.dart';
 import 'firebase_options.dart';
 
 import 'screens/splash_screen.dart';
+import 'screens/login_screen.dart';
+import 'screens/auth/signup_screen.dart';
+import 'screens/auth/phone_input_screen.dart';
+import 'screens/auth/sms_verification_screen.dart';
+import 'screens/auth/reset_password_screen.dart';
+import 'screens/landing_screen.dart';
+import 'screens/profile_screen.dart';
+import 'screens/chat_list_screen.dart';
+import 'screens/notification_screen.dart';
+import 'screens/marketplace_screen.dart';
+import 'screens/menu_screen.dart';
+import 'screens/post_creation_screen.dart';
+import 'screens/post_details_screen.dart';
+import 'screens/search_screen.dart';
 import 'providers/locale_provider.dart';
 
 void main() async {
@@ -28,6 +42,22 @@ class MyApp extends StatelessWidget {
             // اللغة الآن غير مدعومة، فنبقي locale فقط لو تستخدمها بطريقة مخصصة
             locale: provider.locale,
             home: const SplashScreen(),
+            routes: {
+              '/login': (_) => const LoginScreen(),
+              '/signup': (_) => const SignupScreen(),
+              '/phone': (_) => const PhoneInputScreen(),
+              '/verify': (_) => const SmsVerificationScreen(),
+              '/reset': (_) => const ResetPasswordScreen(),
+              '/landing': (_) => const LandingScreen(),
+              '/profile': (_) => const ProfileScreen(),
+              '/chat': (_) => const ChatListScreen(),
+              '/notifications': (_) => const NotificationScreen(),
+              '/marketplace': (_) => const MarketplaceScreen(),
+              '/menu': (_) => const MainMenuScreen(),
+              '/post': (_) => const PostCreationScreen(),
+              '/postDetails': (_) => const PostDetailsScreen(),
+              '/search': (_) => const SearchScreen(),
+            },
           );
         },
       ),

--- a/lib/screens/menu_screen.dart
+++ b/lib/screens/menu_screen.dart
@@ -122,10 +122,8 @@ class MainMenuScreen extends StatelessWidget {
                       await prefs.setBool('isLoggedIn', false);
 
                       if (!context.mounted) return;
-                      Navigator.of(context).pushAndRemoveUntil(
-                        MaterialPageRoute(builder: (_) => const LoginScreen()),
-                        (route) => false,
-                      );
+                      Navigator.of(context)
+                          .pushNamedAndRemoveUntil('/login', (route) => false);
                     },
                   ),
                 ),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -24,9 +24,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('isFirstTime', false);
     if (!mounted) return;
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => const LoginScreen()),
-    );
+    Navigator.of(context).pushReplacementNamed('/login');
   }
 
   void _nextPage() {

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -27,19 +27,15 @@ class _SplashScreenState extends State<SplashScreen> {
     final isFirstTime = prefs.getBool('isFirstTime') ?? true;
     final user = FirebaseAuth.instance.currentUser;
 
-    Widget targetScreen;
+    if (!mounted) return;
     if (user != null) {
-      targetScreen = const LandingScreen();
+      Navigator.of(context).pushReplacementNamed('/landing');
     } else if (isFirstTime) {
-      targetScreen = const OnboardingScreen();
-    } else {
-      targetScreen = const LoginScreen();
-    }
-
-    if (mounted) {
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => targetScreen),
+        MaterialPageRoute(builder: (_) => const OnboardingScreen()),
       );
+    } else {
+      Navigator.of(context).pushReplacementNamed('/login');
     }
   }
 


### PR DESCRIPTION
## Summary
- register all main screens as named routes in `MaterialApp`
- use `/login` route during onboarding flow
- redirect to named routes from splash screen
- ensure logout uses named navigation

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457f466e50832c86d2258488020933