### PR TITLE
Add Firebase messaging and crashlytics

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'firebase_options.dart';
+import 'services/notification_service.dart';
+import 'dart:ui';
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+@pragma('vm:entry-point')
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+}
 
 import 'screens/splash_screen.dart';
 import 'screens/login_screen.dart';
@@ -26,6 +35,14 @@ import 'providers/locale_provider.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
+  PlatformDispatcher.instance.onError = (error, stack) {
+    FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+    return true;
+  };
+  await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
+  await NotificationService.initialize();
   runApp(const MyApp());
 }
 

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:reem_verse_rebuild/screens/auth/signup_screen.dart';
 import 'package:reem_verse_rebuild/screens/auth/email_input_screen.dart';
 import 'package:reem_verse_rebuild/screens/onboarding_screen.dart';
 import '../utils/constants.dart';
+import '../services/notification_service.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -71,6 +72,8 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
         await prefs.remove('savedEmail');
       }
 
+      await NotificationService.initialize();
+
       if (!mounted) return;
       Navigator.of(context).pushReplacementNamed('/landing');
     } on FirebaseAuthException catch (e) {
@@ -133,6 +136,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
       final cred = PhoneAuthProvider.credential(
           verificationId: _verificationId!, smsCode: code);
       await _auth.signInWithCredential(cred);
+      await NotificationService.initialize();
       Navigator.of(context).pushReplacementNamed('/landing');
     } catch (e) {
       ScaffoldMessenger.of(context)

--- a/lib/screens/social_login_screen.dart
+++ b/lib/screens/social_login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'dart:io' show Platform;
 import 'package:shared_preferences/shared_preferences.dart';
+import '../services/notification_service.dart';
 
 class SocialLoginScreen extends StatefulWidget {
   const SocialLoginScreen({super.key});
@@ -24,6 +25,7 @@ class _SocialLoginScreenState extends State<SocialLoginScreen> {
         final OAuthCredential facebookAuthCredential =
             FacebookAuthProvider.credential(result.accessToken!.tokenString);
         await _auth.signInWithCredential(facebookAuthCredential);
+        await NotificationService.initialize();
         await _setLoginFlags();
         _navigateToLanding();
       } else {
@@ -49,6 +51,7 @@ class _SocialLoginScreenState extends State<SocialLoginScreen> {
       );
 
       await _auth.signInWithCredential(oauthCredential);
+      await NotificationService.initialize();
       await _setLoginFlags();
       _navigateToLanding();
     } catch (e) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,34 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+class NotificationService {
+  static final FirebaseMessaging _messaging = FirebaseMessaging.instance;
+
+  static Future<void> initialize() async {
+    await _messaging.requestPermission();
+    await _updateToken();
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+      // Handle foreground messages if needed
+    });
+    FirebaseMessaging.onTokenRefresh.listen((token) async {
+      await _saveToken(token);
+    });
+  }
+
+  static Future<void> _updateToken() async {
+    final token = await _messaging.getToken();
+    if (token != null) {
+      await _saveToken(token);
+    }
+  }
+
+  static Future<void> _saveToken(String token) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user != null) {
+      await FirebaseFirestore.instance.collection('users').doc(user.uid).update({
+        'fcmToken': token,
+      });
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   firebase_auth: ^5.5.3
   cloud_firestore: ^5.6.7
   firebase_storage: ^12.4.5
+  firebase_messaging: ^15.2.6
+  firebase_crashlytics: ^4.3.6
 
   # Media & Location
   just_audio: ^0.10.2


### PR DESCRIPTION
## Summary
- integrate `firebase_messaging` and `firebase_crashlytics`
- request notification permissions and upload FCM token
- report Flutter errors to Crashlytics
- update login flows to register FCM token after sign-in

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c48c5a38832c8640c65937ec8a5c