### PR TITLE
Align Firebase packages and social logins

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'firebase_options.dart';
 
 import 'screens/splash_screen.dart';
@@ -23,9 +26,19 @@ import 'screens/search_screen.dart';
 
 import 'providers/locale_provider.dart';
 
+@pragma('vm:entry-point')
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  FirebaseCrashlytics.instance.log('bg message: ${message.messageId ?? "no-id"}');
+}
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
+  FirebaseAnalytics.instance;
+  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+  await FirebaseMessaging.instance.requestPermission();
   runApp(const MyApp());
 }
 

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -4,7 +4,10 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:flutter/foundation.dart';
 
 class AuthService {
-  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseAuth _auth;
+
+  AuthService({FirebaseAuth? firebaseAuth})
+      : _auth = firebaseAuth ?? FirebaseAuth.instance;
 
   // ✅ Anonymous Sign-in
   Future<UserCredential> signInAnonymously() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,10 +20,13 @@ dependencies:
   shared_preferences: ^2.2.2
 
   # Firebase
-  firebase_core: ^3.13.0
-  firebase_auth: ^5.5.3
-  cloud_firestore: ^5.6.7
-  firebase_storage: ^12.4.5
+  firebase_core: ^2.25.4
+  firebase_auth: ^4.17.4
+  cloud_firestore: ^4.15.4
+  firebase_storage: ^11.6.7
+  firebase_messaging: ^14.7.6
+  firebase_analytics: ^10.6.3
+  firebase_crashlytics: ^3.5.6
 
   # Media & Location
   just_audio: ^0.10.2
@@ -33,8 +36,8 @@ dependencies:
   geolocator: ^14.0.0
 
   # Social login
-  flutter_facebook_auth: ^7.1.2
-  sign_in_with_apple: ^7.0.1
+  flutter_facebook_auth: ^6.0.1
+  sign_in_with_apple: ^6.1.0
 
   # Cards UI / swipe
   swipe_cards: ^2.0.0+1
@@ -43,6 +46,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.1
+  firebase_auth_mocks: ^0.14.2
 
 flutter:
   uses-material-design: true

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:reem_verse_rebuild/services/auth_service.dart';
+
+void main() {
+  group('AuthService', () {
+    test('signInAnonymously returns a user', () async {
+      final auth = MockFirebaseAuth();
+      final service = AuthService(firebaseAuth: auth);
+      final credential = await service.signInAnonymously();
+      expect(credential.user, isNotNull);
+      expect(auth.currentUser, isNotNull);
+    });
+
+    test('signOut clears current user', () async {
+      final auth = MockFirebaseAuth();
+      final service = AuthService(firebaseAuth: auth);
+      await service.signInAnonymously();
+      expect(auth.currentUser, isNotNull);
+      await service.signOut();
+      expect(auth.currentUser, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- align Firebase package versions
- add missing Firebase initialization for messaging and crashlytics
- allow injecting `FirebaseAuth` in `AuthService`
- add basic auth service tests

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c678912c832c9763cefc2b3856e7