### PR TITLE
Clean iOS Podfile constraints

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '15.0'
+platform :ios, '13.0'
 
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
@@ -28,14 +28,6 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
 
-  # ✅ تثبيت Firebase 10.24.0 لحل مشكلة gRPC -G
-  pod 'Firebase/Core', '10.24.0'
-  #pod 'Firebase/Auth', '10.24.0'
-  pod 'Firebase/Firestore', '10.24.0'
-  pod 'Firebase/Messaging', '10.24.0'
-  pod 'Firebase/Storage', '10.24.0'
-  pod 'Firebase/Crashlytics', '10.24.0'
-  pod 'Firebase/Analytics', '10.24.0'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 


### PR DESCRIPTION
## Summary
- bump the minimum iOS version to 13
- remove fixed Firebase pod versions

## Testing
- `pod --version` *(fails: command not found)*
- `flutter clean` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848359e02b8832cb1458c10cd0a6998